### PR TITLE
Corrected improper context naming

### DIFF
--- a/src/app/Handler.ts
+++ b/src/app/Handler.ts
@@ -1,8 +1,8 @@
 'use server';
 
-import { DashboardAction } from '@/context';
+import { HomepageAction } from '@/context';
 
-export default async function Handler(action: DashboardAction) {  
+export default async function Handler(action: HomepageAction) {  
 
   
 

--- a/src/app/Provider.tsx
+++ b/src/app/Provider.tsx
@@ -1,24 +1,25 @@
 "use client";
-import {
-  DashboardAction,
-  DashboardContext,
-  DashboardDispatch,
-  TDashboardContext
-} from "@/context";
+
 import { useReducer } from "react";
 import Handler from "./Handler";
+import {
+  HomepageAction,
+  HomepageContext,
+  HomepageDispatch,
+  THomepageContext
+} from "@/context";
 
-type DashboardProviderProps = {
-  value: TDashboardContext;
+type HomepageProviderProps = {
+  value: THomepageContext;
   children: React.ReactNode;
 };
 
-export default function Provider({ ...props }: DashboardProviderProps) {
+export default function Provider({ ...props }: HomepageProviderProps) {
   const { value, children } = props;
 
   const [ctx, dispatch] = useReducer(Reducer, value);
 
-  const Manager = async (action: DashboardAction) => {
+  const Manager = async (action: HomepageAction) => {
     try {
       const res = await Handler(action);
     } catch (err) {
@@ -29,15 +30,15 @@ export default function Provider({ ...props }: DashboardProviderProps) {
   };
 
   return (
-    <DashboardContext.Provider value={ctx}>
-      <DashboardDispatch.Provider value={Manager}>
+    <HomepageContext.Provider value={ctx}>
+      <HomepageDispatch.Provider value={Manager}>
         {children}
-      </DashboardDispatch.Provider>
-    </DashboardContext.Provider>
+      </HomepageDispatch.Provider>
+    </HomepageContext.Provider>
   );
 }
 
-const Reducer = (subject: TDashboardContext, action: DashboardAction) => {
+const Reducer = (subject: THomepageContext, action: HomepageAction) => {
   console.log(action);
 
   return subject;

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,32 +1,34 @@
-'use client';
+"use client";
 
-import { Credentials } from 'google-auth-library';
-import { useContext, createContext } from 'react';
+import { Credentials } from "google-auth-library";
+import { useContext, createContext } from "react";
 
-export type TDashboardContext = {
+export type THomepageContext = {
   credentials: Credentials;
 };
 
-export type DashboardAction = {
+export type HomepageAction = {
   type: string;
 };
 
-export type TDashboardDispatch = (action: DashboardAction) => Promise<void>;
+export type THomepageDispatch = (action: HomepageAction) => Promise<void>;
 
-const DashboardContext = createContext<TDashboardContext | null>(null);
-const DashboardDispatch = createContext(async (action: DashboardAction) => {});
+const HomepageContext = createContext<THomepageContext | null>(null);
+const HomepageDispatch = createContext(
+  async (action: HomepageAction) => {}
+);
 
-const useDashboard = () => {
-  return useContext(DashboardContext);
+const useHomepage = () => {
+  return useContext(HomepageContext);
 };
 
-const useDashboardDispatch = () => {
-  return useContext(DashboardDispatch);
+const useHomepageDispatch = () => {
+  return useContext(HomepageDispatch);
 };
 
 export {
-  useDashboard,
-  useDashboardDispatch,
-  DashboardContext,
-  DashboardDispatch
+  useHomepage,
+  useHomepageDispatch,
+  HomepageContext,
+  HomepageDispatch
 };


### PR DESCRIPTION
Renamed all DashboardContext items to HomepageContext. The previous naming scheme was confusing. 