### PR TITLE
Input Components, Home and Global Style Updates

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -14,8 +14,8 @@ export default async function Page(){
         <h1>BayView </h1>
         <h1>Admin Login</h1>
         <form>
-            <UserInput icon={{ icon: faUser }} type="text" placeholder="Username" required />
-            <UserInput icon={{ icon: faKey }} type="password" placeholder="Password" required />
+            <UserInput icon={faUser} type="text" placeholder="Username" required />
+            <UserInput icon={faKey} type="password" placeholder="Password" required />
             <button type="submit">Login</button>
         </form>
 

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -14,8 +14,8 @@ export default async function Page(){
         <h1>BayView </h1>
         <h1>Admin Login</h1>
         <form>
-            <UserInput icon={faUser} type="text" placeholder="Username" required />
-            <UserInput icon={faKey} type="password" placeholder="Password" required />
+            <UserInput icon={{icon:faUser}} type="text" placeholder="Username" required />
+            <UserInput icon={{icon:faKey}} type="password" placeholder="Password" required />
             <button type="submit">Login</button>
         </form>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,7 @@
   --gray-200: rgb(82, 83, 86);
   --gray-100: rgb(92, 93, 96);
   --background-color-light: rgb(244 244 245); /* Match bg-zinc-100 */
-  --background-color-dark: rgb(24 24 27); /* Match bg-zinc-800 */
+  --background-color-dark: #09090b; /* Match bg-zinc-950 */
   --background-color: var(--background-color-light);
 }
 
@@ -38,7 +38,9 @@ body {
   font-weight: 500;
   overflow: hidden;
   color-scheme: auto;
-  @apply bg-zinc-100 dark:bg-zinc-800
+  @apply text-base;
+  @apply text-zinc-900 dark:text-white;
+  @apply bg-zinc-100 dark:bg-zinc-950
 }
 
 body {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,8 +28,8 @@
 }
 
 html {
-  width: 99vw;
-  height: 99vh;
+  width: 100vw;
+  height: 100vh;
 }
 
 html,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,8 +12,8 @@
   --gray-300: rgb(72, 73, 76);
   --gray-200: rgb(82, 83, 86);
   --gray-100: rgb(92, 93, 96);
-  --background-color-light: #d2d2d2;
-  --background-color-dark: rgb(32, 33, 36);
+  --background-color-light: rgb(244 244 245); /* Match bg-zinc-100 */
+  --background-color-dark: rgb(24 24 27); /* Match bg-zinc-800 */
   --background-color: var(--background-color-light);
 }
 
@@ -37,8 +37,8 @@ body {
   font-family: var(--font-barlow);
   font-weight: 500;
   overflow: hidden;
-  color-scheme: dark;
-  background: var(--background-color-dark);
+  color-scheme: auto;
+  @apply bg-zinc-100 dark:bg-zinc-800
 }
 
 body {

--- a/src/app/home/[id]/page.module.css
+++ b/src/app/home/[id]/page.module.css
@@ -1,0 +1,11 @@
+.layout {
+    height: 100%; 
+    width: 100%; 
+    overflow: scroll;
+}
+
+.contentGrid {
+    @apply grid gap-2 gap-y-4 sm:gap-y-2 grid-cols-1 mt-24 mb-12 px-8;
+    @apply sm:gap-y-2 md:grid-cols-2 md:gap-4 2xl:grid-cols-3 2xl:gap-8
+}
+  

--- a/src/app/home/[id]/page.tsx
+++ b/src/app/home/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import styles from "./page.module.css";
 
 export default function Page({
   params
@@ -14,9 +15,15 @@ export default function Page({
   const { id } = params;
 
   return (
-    <div>
-      {id}
-      <button onClick={async (e) => push("/auth/logout")}>Logout</button>
-    </div>
+	<div className={styles.layout}>
+		<div>
+			{id}
+			<button onClick={async (e) => push("/auth/logout")}>Logout</button>
+		</div>
+		{/* <TopBar></TopBar> */}
+		<div className={styles.contentGrid}>
+			{/* Card Components here */}
+		</div>
+	</div>
   );
 }

--- a/src/app/home/layout.css
+++ b/src/app/home/layout.css
@@ -1,4 +1,0 @@
-.layout {
-  height: 100%; 
-  width: 100%; 
-}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,5 +1,0 @@
-import styles from "./page.module.css";
-
-export default function Page() {
-  return <div className={styles.Page}></div>;
-}

--- a/src/components/Button/button.module.css
+++ b/src/components/Button/button.module.css
@@ -1,34 +1,29 @@
+/* Common Button Styles */
 .button {
-  @apply rounded-full bg-black text-white font-bold py-3 px-8 cursor-pointer transition ease-in duration-200;
+  @apply text-white font-bold rounded-full py-3 px-8 cursor-pointer transition ease-in duration-200;
+  @apply flex align-middle justify-items-center outline-none ring-2 ring-transparent;
 }
 
-.button:hover {
-  @apply bg-zinc-600 disabled:bg-black;
+.button:disabled {
+  @apply opacity-25 cursor-not-allowed;
 }
 
-
-.button:active {
-  @apply bg-zinc-800;
+/* Primary (Black) Button Styles */
+.button.primary {
+  @apply bg-black;
 }
 
-.button:focus {
-  @apply outline-none ring-2 ring-zinc-500;
+.button.primary:not(:disabled) {
+  @apply hover:bg-zinc-800 active:bg-zinc-700 focus:ring-zinc-700;
 }
 
-.primaryButton {
-  @apply rounded-full bg-red-600 text-white font-bold py-3 px-8 cursor-pointer transition ease-in duration-200;
+/* Secondary (Red) Button Styles */
+.button.secondary {
+  @apply bg-red-600;
 }
 
-.primaryButton:hover {
-  @apply bg-red-500 disabled:bg-red-600;
-}
-
-.primaryButton:active {
-  @apply bg-red-700;
-}
-
-.primaryButton:focus {
-  @apply outline-none ring-2 ring-red-500;
+.button.secondary:not(:disabled) {
+  @apply hover:bg-red-500 active:bg-red-400 focus:ring-red-400;
 }
 
 .inlineIcon {

--- a/src/components/Button/button.module.css
+++ b/src/components/Button/button.module.css
@@ -1,10 +1,69 @@
 .button {
-  border: none;
-  padding: 1rem 2rem;
-  background: black;
-  color: white;
-  font-size: 1.4rem;
-  border-radius: 6rem;
-  font-weight: bold;
-  cursor: pointer;
+  @apply rounded-full bg-black text-white font-bold py-3 px-8 cursor-pointer transition ease-in duration-200;
+}
+
+.button:hover {
+  @apply bg-zinc-600 disabled:bg-black;
+}
+
+
+.button:active {
+  @apply bg-zinc-800;
+}
+
+.button:focus {
+  @apply outline-none ring-2 ring-zinc-500;
+}
+
+.primaryButton {
+  @apply rounded-full bg-red-600 text-white font-bold py-3 px-8 cursor-pointer transition ease-in duration-200;
+}
+
+.primaryButton:hover {
+  @apply bg-red-500 disabled:bg-red-600;
+}
+
+.primaryButton:active {
+  @apply bg-red-700;
+}
+
+.primaryButton:focus {
+  @apply outline-none ring-2 ring-red-500;
+}
+
+.inlineIcon {
+    @apply pr-3;
+}
+
+.inlineIcon svg {
+  @apply w-[1.2rem] h-[1.2rem] pb-[0.05rem];
+}
+
+.spinner {
+  height: 20px;
+  width: 20px;
+  border-width: 3px;
+  border-style: solid;
+  border-color: rgb(255, 255, 255) rgb(255, 255, 255) rgba(255, 255, 255, 0.5) rgba(255, 255, 255, 0.5);
+  border-radius: 100%;
+  margin-top: 2px;
+  animation: clockwise 0.7s linear infinite;
+}
+
+@keyframes clockwise {
+  0% {
+    transform: rotate(0deg);
+  }
+  20% {
+    transform: rotate(72deg);
+  }
+  50% {
+    transform: rotate(180deg);
+  }
+  80% {
+    transform: rotate(288deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,39 +1,37 @@
 'use client';
 import { ButtonHTMLAttributes, DetailedHTMLProps, ReactNode, useState } from 'react';
 import styles from './button.module.css';
-import { FontAwesomeIcon, FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
-import { IconDefinition, library, icon, IconProp } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import { IconDefinition} from "@fortawesome/fontawesome-svg-core";
 
-type ButtonProps = {
-  icon?: IconDefinition;
-  red?: boolean;
-  children?: ReactNode;
-  className?: string;
-} & DetailedHTMLProps<
-  ButtonHTMLAttributes<HTMLButtonElement>, 
-  HTMLButtonElement>;
+type ButtonProps = ({
+} & DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
+    icon?: IconDefinition;
+    variant?:
+      | 'primary'
+      | 'secondary';
+  });
 
 export default function Button({
-  red,
-  className,
   ...props
 }: ButtonProps) {
   const [isPending, setIsPending] = useState(false); 
+  const classNames = [props.className, props.variant ? styles[props.variant] : styles.primary, styles.button].join(' ');
   
   const setPending = (bool_:boolean) => {
     setIsPending(bool_);
   };
 
-  // If icon exists add to libary
-  if(props.icon)
-		library.add(props.icon);
-
   return (
-  <button {...props} className={`${className} ${red? styles.primaryButton : styles.button} disabled:opacity-25 flex align-center justify-items-center`}>
-    	<div className={props.icon? styles.inlineIcon: ''}>
-				{props.icon && <FontAwesomeIcon className="text-white w-3" size="lg" icon={icon(props.icon)}/>}
-			</div>
+  <button {...props} className={`${classNames}`}>
+    	{ props.icon && 
+        <div className={styles.inlineIcon}>
+				  <FontAwesomeIcon className="text-white w-3" size="lg" icon={props.icon}/>
+        </div> 
+      }
       <div className='w-full justify-self-center'>{props.children}</div>
-      <div className={isPending? styles.spinner + " ml-3 flex-none": ''}></div>
+      { isPending && 
+        <div className={[styles.spinner].join('ml-3 fex-none')}></div> 
+      }
   </button>)
 }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,9 +1,39 @@
 'use client';
-import { ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
+import { ButtonHTMLAttributes, DetailedHTMLProps, ReactNode, useState } from 'react';
 import styles from './button.module.css';
-export default function Button({
-  ...props
-}: DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>) {
+import { FontAwesomeIcon, FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
+import { IconDefinition, library, icon, IconProp } from "@fortawesome/fontawesome-svg-core";
 
-  return <button {...props} className={props.className + ' ' + styles.button} />
+type ButtonProps = {
+  icon?: IconDefinition;
+  red?: boolean;
+  children?: ReactNode;
+  className?: string;
+} & DetailedHTMLProps<
+  ButtonHTMLAttributes<HTMLButtonElement>, 
+  HTMLButtonElement>;
+
+export default function Button({
+  red,
+  className,
+  ...props
+}: ButtonProps) {
+  const [isPending, setIsPending] = useState(false); 
+  
+  const setPending = (bool_:boolean) => {
+    setIsPending(bool_);
+  };
+
+  // If icon exists add to libary
+  if(props.icon)
+		library.add(props.icon);
+
+  return (
+  <button {...props} className={`${className} ${red? styles.primaryButton : styles.button} disabled:opacity-25 flex align-center justify-items-center`}>
+    	<div className={props.icon? styles.inlineIcon: ''}>
+				{props.icon && <FontAwesomeIcon className="text-white w-3" size="lg" icon={icon(props.icon)}/>}
+			</div>
+      <div className='w-full justify-self-center'>{props.children}</div>
+      <div className={isPending? styles.spinner + " ml-3 flex-none": ''}></div>
+  </button>)
 }

--- a/src/components/HomePage/Card/card.module.css
+++ b/src/components/HomePage/Card/card.module.css
@@ -1,0 +1,4 @@
+.defaultCard {
+    @apply w-full p-5 bg-white border border-zinc-200 rounded-xl dark:bg-zinc-800 dark:border-zinc-800;
+    @apply transition-all duration-300 ease-in-out;
+}

--- a/src/components/HomePage/Card/index.tsx
+++ b/src/components/HomePage/Card/index.tsx
@@ -1,0 +1,29 @@
+'use client';
+import React, { ReactNode, useState, HTMLProps } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
+import styles from './card.module.css';
+
+type CardProps = {
+	title: string;
+	subtitle?: string;
+	id?: string;
+	children?: ReactNode;
+} & HTMLProps<HTMLBodyElement>;
+
+export default function Card({ title, subtitle, children, ...props }: CardProps) {
+	const [isOpen, setIsOpen] = useState(true);
+
+	return (
+		<div  className={`${props.className} ${styles.defaultCard} ${isOpen ? 'max-h-[45rem] overflow-scroll' : 'max-h-24 overflow-clip'}`}>
+			<button className="flex items-center sticky" onClick={() => setIsOpen(!isOpen)}>
+				<FontAwesomeIcon className="w-4 pr-2" size="lg" icon={isOpen ? faAngleDown : faAngleUp}></FontAwesomeIcon>
+				<h1 className="text-2xl font-bold">{title}</h1>
+			</button>
+			<h2 className="pl-6 text-zinc-400">{subtitle}</h2>
+			<div className={`px-3 pb-2 pt-3`}>
+                {children}
+			</div>
+		</div>
+	);
+}

--- a/src/components/HomePage/Card/index.tsx
+++ b/src/components/HomePage/Card/index.tsx
@@ -7,17 +7,18 @@ import styles from './card.module.css';
 type CardProps = {
 	title: string;
 	subtitle?: string;
-	id?: string;
-	children?: ReactNode;
 } & HTMLProps<HTMLBodyElement>;
 
-export default function Card({ title, subtitle, children, ...props }: CardProps) {
+export default function Card({ ...props }: CardProps) {
+
+	const {children, className, title, subtitle} = props; 
+	
 	const [isOpen, setIsOpen] = useState(true);
 
 	return (
-		<div  className={`${props.className} ${styles.defaultCard} ${isOpen ? 'max-h-[45rem] overflow-scroll' : 'max-h-24 overflow-clip'}`}>
+		<div  className={`${className} ${styles.defaultCard} ${isOpen ? 'max-h-[45rem] overflow-scroll' : 'max-h-24 overflow-clip'}`}>
 			<button className="flex items-center sticky" onClick={() => setIsOpen(!isOpen)}>
-				<FontAwesomeIcon className="w-4 pr-2" size="lg" icon={isOpen ? faAngleDown : faAngleUp}></FontAwesomeIcon>
+				<FontAwesomeIcon className="w-4 pr-2" size="lg" icon={isOpen ? faAngleDown : faAngleUp}/>
 				<h1 className="text-2xl font-bold">{title}</h1>
 			</button>
 			<h2 className="pl-6 text-zinc-400">{subtitle}</h2>

--- a/src/components/Input/InputPair/index.tsx
+++ b/src/components/Input/InputPair/index.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { IconDefinition, library, icon } from "@fortawesome/fontawesome-svg-core";
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import styles from "./inputpair.module.css";
 
 type InputPairProps = {
@@ -11,19 +11,17 @@ type InputPairProps = {
 	children: [ReactNode, ReactNode];
 };
 
-export default function InputPair({ className, ...props }: InputPairProps) {
+export function InputPair({ ...props }: InputPairProps) {
 	
-	// If icon exists add to libary
-    if(props.icon)
-		library.add(props.icon);
-
+	const {className, icon, children} = props; 
+	
 	return (
 		<div className={`${className} flex items-center justify-between w-100`}>
-			<div className="w-full">{props.children[0]}</div>
+			<div className="w-full">{children[0]}</div>
 			<div className={styles.inlineIcon}>
-				{props.icon ? <FontAwesomeIcon className="dark:text-white text-black w-3" size="lg" icon={icon(props.icon)} /> : <div className="w-3"></div>}
+				{icon ? <FontAwesomeIcon className="dark:text-white text-black w-3" size="lg" icon={icon} /> : <div className="w-3"></div>}
 			</div>
-			<div className="w-full">{props.children[1]}</div>
+			<div className="w-full">{children[1]}</div>
 		</div>
 	);
 }

--- a/src/components/Input/InputPair/index.tsx
+++ b/src/components/Input/InputPair/index.tsx
@@ -11,7 +11,7 @@ type InputPairProps = {
 	children: [ReactNode, ReactNode];
 };
 
-export function InputPair({ ...props }: InputPairProps) {
+export default function InputPair({ ...props }: InputPairProps) {
 	
 	const {className, icon, children} = props; 
 	

--- a/src/components/Input/InputPair/index.tsx
+++ b/src/components/Input/InputPair/index.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ReactNode } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { IconDefinition, library, icon } from "@fortawesome/fontawesome-svg-core";
+import styles from "./inputpair.module.css";
+
+type InputPairProps = {
+	icon?: IconDefinition;
+	className?: string;
+	children: [ReactNode, ReactNode];
+};
+
+export default function InputPair({ className, ...props }: InputPairProps) {
+	
+	// If icon exists add to libary
+    if(props.icon)
+		library.add(props.icon);
+
+	return (
+		<div className={`${className} flex items-center justify-between w-100`}>
+			<div className="w-full">{props.children[0]}</div>
+			<div className={styles.inlineIcon}>
+				{props.icon ? <FontAwesomeIcon className="dark:text-white text-black w-3" size="lg" icon={icon(props.icon)} /> : <div className="w-3"></div>}
+			</div>
+			<div className="w-full">{props.children[1]}</div>
+		</div>
+	);
+}

--- a/src/components/Input/InputPair/inputpair.module.css
+++ b/src/components/Input/InputPair/inputpair.module.css
@@ -1,0 +1,3 @@
+.inlineIcon {
+    @apply mx-3 mt-4;
+}

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -40,8 +40,6 @@ const UserInput = ({ ...props }: UserInputProps) => {
   const [input, validateInput] = useInputValidation();
   const onKeyUp = useCallback((event: SyntheticEvent) => validateInput((event.currentTarget as HTMLInputElement).value), [validateInput]);
 
-  const [type, setHidden] = useState(props.type);
-
   return (
     <div className={className}>
       { label ? (
@@ -53,7 +51,7 @@ const UserInput = ({ ...props }: UserInputProps) => {
       }
       <div className={styles.inputWrapper}>
         {icon && <FontAwesomeIcon className={styles.icon} {...icon} />}
-        <input className={styles.input} id={id} {...props} onKeyUp={onKeyUp} />
+        <input className={styles.input} {...props} />
         {children}
       </div>
     </div>

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -8,12 +8,14 @@ import {
 
 import {
   FontAwesomeIcon,
+  FontAwesomeIconProps
 } from "@fortawesome/react-fontawesome";
+import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { IconDefinition} from "@fortawesome/fontawesome-svg-core";
 import styles from "./input.module.css";
 
 type UserInputProps = {
-  icon?: IconDefinition;
+  icon?: Omit<FontAwesomeIconProps, "icon"> & { icon: IconProp };
   label?:string; 
 } & DetailedHTMLProps<
   InputHTMLAttributes<HTMLInputElement>,
@@ -50,7 +52,7 @@ const UserInput = ({ ...props }: UserInputProps) => {
         <div className="w-full h-7"></div>
       }
       <div className={styles.inputWrapper}>
-        {icon && <FontAwesomeIcon className={styles.icon} icon={icon} />}
+        {icon && <FontAwesomeIcon className={styles.icon} {...icon} />}
         <input className={styles.input} id={id} {...props} onKeyUp={onKeyUp} />
         {children}
       </div>

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -3,21 +3,18 @@ import {
   DetailedHTMLProps,
   InputHTMLAttributes,
   useCallback,
-  useState
+  useState, SyntheticEvent
 } from "react";
 
 import {
   FontAwesomeIcon,
-  FontAwesomeIconProps
 } from "@fortawesome/react-fontawesome";
-import { IconProp } from "@fortawesome/fontawesome-svg-core";
+import { IconDefinition} from "@fortawesome/fontawesome-svg-core";
 import styles from "./input.module.css";
 
 type UserInputProps = {
-  icon?: Omit<FontAwesomeIconProps, "icon"> & { icon: IconProp };
-  label?: string;
-	id?: string;
-  className?: string;
+  icon?: IconDefinition;
+  label:string; 
 } & DetailedHTMLProps<
   InputHTMLAttributes<HTMLInputElement>,
   HTMLInputElement
@@ -34,9 +31,12 @@ function useInputValidation(initialValue: string = "") {
 	return [input, validateInput] as const;
 }
 
-const UserInput = ({ icon, label, id, children, className, ...props }: UserInputProps) => {
+const UserInput = ({ ...props }: UserInputProps) => {
+	
+  const {icon, label, id, children, className} = props; 
+	
   const [input, validateInput] = useInputValidation();
-  const onKeyUp = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => validateInput(event.currentTarget.value), [validateInput]);
+  const onKeyUp = useCallback((event: SyntheticEvent) => validateInput((event.currentTarget as HTMLInputElement).value), [validateInput]);
 
   const [type, setHidden] = useState(props.type);
 
@@ -50,7 +50,7 @@ const UserInput = ({ icon, label, id, children, className, ...props }: UserInput
         <div className="w-full h-7"></div>
       }
       <div className={styles.inputWrapper}>
-        {icon && <FontAwesomeIcon className={styles.icon} {...icon} />}
+        {icon && <FontAwesomeIcon className={styles.icon} icon={icon} />}
         <input className={styles.input} id={id} {...props} onKeyUp={onKeyUp} />
         {children}
       </div>

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -2,7 +2,7 @@
 import {
   DetailedHTMLProps,
   InputHTMLAttributes,
-  useRef,
+  useCallback,
   useState
 } from "react";
 
@@ -15,36 +15,45 @@ import styles from "./input.module.css";
 
 type UserInputProps = {
   icon?: Omit<FontAwesomeIconProps, "icon"> & { icon: IconProp };
+  label?: string;
+	id?: string;
+  className?: string;
 } & DetailedHTMLProps<
   InputHTMLAttributes<HTMLInputElement>,
   HTMLInputElement
 >;
 
-const UserInput = ({ ...props }: UserInputProps) => {
-  const { icon } = props;
+function useInputValidation(initialValue: string = "") {
+	const [input, setInput] = useState(initialValue);
 
-  const [input, setInput] = useState("");
+	const validateInput = (value: string): void => {
+		// Validation logic here
+		setInput(value);
+	};
 
-  const validateInput = (value: string) => {
-    setInput(value);
-  };
+	return [input, validateInput] as const;
+}
+
+const UserInput = ({ icon, label, id, children, className, ...props }: UserInputProps) => {
+  const [input, validateInput] = useInputValidation();
+  const onKeyUp = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => validateInput(event.currentTarget.value), [validateInput]);
 
   const [type, setHidden] = useState(props.type);
 
   return (
-    <div className={styles.inputWrapper}>
-      <label htmlFor={props.id}>{props.placeholder}</label>
-      <span className={styles.input}>
-        {icon && <FontAwesomeIcon {...icon} />}
-        <input
-          {...props}
-          onKeyUp={({ currentTarget }) =>
-            validateInput(currentTarget.value)
-          }
-          autoComplete='new-password'
-        />
-        {props.children}
-      </span>
+    <div className={className}>
+      { label ? (
+        <label className={styles.label} htmlFor={id}>
+          {label}
+        </label>)
+        :
+        <div className="w-full h-7"></div>
+      }
+      <div className={styles.inputWrapper}>
+        {icon && <FontAwesomeIcon className={styles.icon} {...icon} />}
+        <input className={styles.input} id={id} {...props} onKeyUp={onKeyUp} />
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -14,7 +14,7 @@ import styles from "./input.module.css";
 
 type UserInputProps = {
   icon?: IconDefinition;
-  label:string; 
+  label?:string; 
 } & DetailedHTMLProps<
   InputHTMLAttributes<HTMLInputElement>,
   HTMLInputElement

--- a/src/components/Input/input.module.css
+++ b/src/components/Input/input.module.css
@@ -1,40 +1,21 @@
 .inputWrapper {
-	background: #f2f2f2;
-
-	display: flex;
-	flex-direction: column;
-	position: relative;
-	border-radius: 6rem;
-	justify-content: center;
-	width: 50%;
-	margin: 1rem 0;
+	@apply w-full pb-2 relative;
 }
 
-.inputWrapper label {
-	color: black;
+.label {
+  @apply block pl-3 h-7 text-base;
+}
+
+.input {	
+  @apply w-full text-base rounded-full focus:outline-none;
+  @apply bg-zinc-50 border dark:border-zinc-600 border-zinc-300 focus:ring-red-500 caret-red-500 focus:border-red-500 dark:bg-zinc-700 dark:border-zinc-500 dark:placeholder-zinc-400;
+  padding: 0.75rem 1rem 0.75rem 3.1rem;
+} 
+
+.icon {
+	@apply text-lg;
+    padding: 0.5rem 0 0.4rem 1rem;
 	position: absolute;
-	visibility: hidden;
-}
-
-.input {
-	display: flex;
-	align-items: center;
-}
-
-.input svg {
-	font-size: 1.2rem;
-	color: rgba(0, 0, 0, 0.46);
-	padding: 0.4rem 0 0.4rem 1rem;
-	width: 2rem;
-	text-align: center;
-}
-
-.input input {
-	background-color: transparent;
-	border: none;
-	outline: none;
-	color: black;
-	font-size: 1rem;
-	padding: 0.8rem 0.6rem;
-	width: 100%;
+	left: 0.2rem;
+	top: 0.55rem;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: ["./src/app/**/*.{js,ts,jsx,tsx,mdx}"],
+  content: ["./src/app/**/*.{js,ts,jsx,tsx,mdx}","./src/components/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {}
   },


### PR DESCRIPTION
### Miscellaneous Changes: 
- Modifies the Tailwind config to include `/components` 
- Cleans up unused files pertaining to `/home`
- Sets new global styles inline with the updated Figma Mockup. Related to this, I've enabled the swap between a dark and light appearance for background colors and inputs. We should discuss if we want to move to something that enables both system appearance and manual selection. This would be effective for preserving the look of pages such as the admin dashboard if we decide to intentionally leave inputs dark [https://tailwindcss.com/docs/dark-mode#supporting-system-preference-and-manual-selection](url)

### New Components, Input and Home Page Updates
- **Introduces a card component** for use on the home page. The initial version allows expanding / collapsing, but is open to further refinement. There are`title` and optional `subtitle` props. Related to this, I've defined a css grid for the user cards in the `home/[id]/page.tsx` Here's an example with nested components: <img width="484" alt="Screenshot 2023-10-28 at 2 48 38 PM" src="https://github.com/heyitsmass/BayView/assets/38991991/7f72a737-b29b-481b-b9ac-1e104df11ac1">
- **Introduces Input Pair and Input Refinements**: 
Input pair wraps two input components and allows for an optional icon (such as the arrow depicted below). Icons are defined by a passed `iconDeclaration`. Related to this, inputs now have an optional `label` prop.
  ```jsx
  <InputPair icon={faArrowRight}>
	  <Input label="..." name="..." icon={{ icon: faExample }} placeholder="..." required />
	  <Input label="..." name="..." icon={{ icon: faExample }} placeholder="..." required />
  </InputPair>
  ```
  <img width="465" alt="Screenshot 2023-10-28 at 3 46 39 PM" src="https://github.com/heyitsmass/BayView/assets/38991991/bd8bb225-f129-4aff-bbbe-69e35e09e89d">
- **Button Updates:** A new optional variant prop defines either a primary or secondary button style which is defined in the corresponding css. For example, by setting the `variant="secondary"` style, we produce the red button style as seen in Figma mockups. If variant is absent, we default to the primary style (black). In a similar way to input pair, a icon is able to be passed as a prop. Finally, an optional spinner prop is in-progress, to display loading states:
  <img width="465" alt="Screenshot 2023-10-28 at 4 05 06 PM" src="https://github.com/heyitsmass/BayView/assets/38991991/35318db1-d08f-4d27-849e-62a1f6a5bf0c">
  ![buttons](https://github.com/heyitsmass/BayView/assets/38991991/393dbced-a04c-497c-8727-54ac2749a4ae)

