### PR TITLE
Add Itinerary Title Dialog

### DIFF
--- a/src/components/ItineraryTitleDialog/index.tsx
+++ b/src/components/ItineraryTitleDialog/index.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useState, HTMLProps } from "react";
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Button from "@/components/Button";
-export default function SetLocationModal({ open, onClose }) {
+export default function SetLocationModal(props: { open: boolean, onClose: any }) {
   if (!open) return null;
   return (
     <div className="block fixed w-full h-full bg-black/30">
@@ -17,7 +17,7 @@ export default function SetLocationModal({ open, onClose }) {
           <FontAwesomeIcon
             className="absolute ml-10 mt-2"
             icon={faClose}
-            onClick={onClose}
+            onClick={props.onClose}
           />
         </div>
         <div className="block mt-7">

--- a/src/components/ItineraryTitleDialog/index.tsx
+++ b/src/components/ItineraryTitleDialog/index.tsx
@@ -1,0 +1,39 @@
+"use client";
+import React, { ReactNode, useState, HTMLProps } from "react";
+import { faClose } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Button from "@/components/Button";
+export default function SetLocationModal({ open, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="block fixed w-full h-full bg-black/30">
+      <div
+        className={
+          "block bg-white fixed max-w-xl -translate-x-1/2 -translate-y-1/2 top-1/3 left-1/2 border-zinc-200 rounded-xl pl-4 py-4 pr-20 shadow-red-600 z-0"
+        }
+      >
+        <div className="inline">
+          <h1 className="text-2xl font-bold inline mr-10"> Select Location </h1>
+          <FontAwesomeIcon
+            className="absolute ml-10 mt-2"
+            icon={faClose}
+            onClick={onClose}
+          />
+        </div>
+        <div className="block mt-7">
+          <label className="block">
+            <input type="radio" value="Disneyland" name="Location" /> Disneyland
+          </label>
+          <label className="block mt-3">
+            <input type="radio" value="WaltDisneyWorld" name="Location" /> Walt
+            Disney World
+          </label>
+          <Button type="submit" className="mt-8">
+            {" "}
+            Confirm{" "}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ItineraryTitleDialog/index.tsx
+++ b/src/components/ItineraryTitleDialog/index.tsx
@@ -3,10 +3,16 @@ import React, { ReactNode, useState, HTMLProps } from "react";
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Button from "@/components/Button";
-export default function SetLocationModal(props: { open: boolean, onClose: any }) {
-  if (!open) return null;
-  return (
-    <div className="block fixed w-full h-full bg-black/30">
+import { SyntheticEvent } from "react";
+
+type LocationModalProps = { 
+  open: boolean
+  onClose: (e?:SyntheticEvent) => void 
+} 
+
+export default function SetLocationModal({open, onClose}:LocationModalProps) {
+  return <>
+    {open && <div className="block fixed w-full h-full bg-black/30">
       <div
         className={
           "block bg-white fixed max-w-xl -translate-x-1/2 -translate-y-1/2 top-1/3 left-1/2 border-zinc-200 rounded-xl pl-4 py-4 pr-20 shadow-red-600 z-0"
@@ -17,7 +23,7 @@ export default function SetLocationModal(props: { open: boolean, onClose: any })
           <FontAwesomeIcon
             className="absolute ml-10 mt-2"
             icon={faClose}
-            onClick={props.onClose}
+            onClick={onClose}
           />
         </div>
         <div className="block mt-7">
@@ -35,5 +41,6 @@ export default function SetLocationModal(props: { open: boolean, onClose: any })
         </div>
       </div>
     </div>
-  );
+    }
+  </>
 }


### PR DESCRIPTION
### Description
This PR creates the dialog associated with the itinerary title component. With this dialog, the user can select which location they are planning to attend: Disneyland or Disney World. The dialog can be opened when a specific element is clicked and closed when the "X" button is clicked.

### Motivation and Context
This dialog will be used to select the location. The location can be saved in order to ensure that searches for bookings are focused on 

### How Has This Been Tested?

### Screenshots (if appropriate):
<img width="322" alt="Screenshot 2023-11-02 at 3 25 12 PM" src="https://github.com/heyitsmass/BayView/assets/120698868/ca7470fc-de54-4fb7-a8eb-aad5f308d3ba">

_Dialog Demo_
https://github.com/heyitsmass/BayView/assets/120698868/9295b5f3-d7b6-46cc-a82e-229966bfd619

_Note: Would still need to add the updated location to the database_

### Types of changes
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Refactoring (non-breaking change)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [ ] -  My code follows the code style of this project.
- [ ] -  My change requires a change to the documentation.
- [ ] -  I have updated the documentation accordingly.
- [ ] -  I have read the CONTRIBUTING document.
- [ ] -  I have added tests to cover my changes.