### PR TITLE
Calendar Input Refactor / Implementation & Bug Fix

### DIFF
--- a/src/components/HomePage/Card/DiningCard/index.tsx
+++ b/src/components/HomePage/Card/DiningCard/index.tsx
@@ -12,6 +12,7 @@ import Input from '@/components/Input';
 import InputPair from '@/components/Input/InputPair';
 import Button from '@/components/Button';
 import Card from '@/components/HomePage/Card';
+import BayviewCalendar from '@/components/Input/BayviewCalendar';
 
 export default function DiningCard() {
   return (
@@ -27,11 +28,12 @@ export default function DiningCard() {
           type="number"
           max={10}
         ></Input>
-        <Input
-          label="Booking Date"
-          icon={{ icon: faCalendarDays }}
-          placeholder="Booking Date"
-        ></Input>
+        <BayviewCalendar
+					  label="Booking Date"
+						name="booking_date"
+            placeholder="Booking Date"
+						minDate={new Date(Date.now())}
+				/>
         <InputPair icon={faArrowRight}>
           <Input icon={{icon:faClock}} label="Start Time" placeholder="Start time"></Input>
           <Input icon={{icon:faClock}} label="End Time" placeholder="End time"></Input>

--- a/src/components/HomePage/Card/FlightCard/Presentations/Confirmed.tsx
+++ b/src/components/HomePage/Card/FlightCard/Presentations/Confirmed.tsx
@@ -13,8 +13,10 @@ export default function Confirmed() {
 	// Extracting the selected offer details
 	const { selectedOffer, returnFlight } = flightState.selectState;
 
-	const prettyPrintDate = (dateString) =>
-		`${parseInt(dateString.substring(5, 7), 10)}/${parseInt(dateString.substring(8, 10), 10)}/${dateString.substring(2, 4)}`;
+	const prettyPrintDate = dateString => {
+		const d = new Date(dateString);
+		return `${(d.getMonth() + 1).toString().padStart(2, '0')}/${d.getDate().toString().padStart(2, '0')}/${d.getFullYear().toString().slice(-2)}`;
+	};
 
 	const isoDurationToMilliseconds = (duration) => {
 		const hoursMatch = duration.match(/(\d+)H/);

--- a/src/components/HomePage/Card/FlightCard/Presentations/Search.tsx
+++ b/src/components/HomePage/Card/FlightCard/Presentations/Search.tsx
@@ -9,6 +9,7 @@ import { FlightContext } from '../flightState';
 import { flightSearchAction } from '../flightActions';
 import { stepDetails } from '..';
 import { BlurOpacityAnimation } from '@/components/Animations/AnimatePresenceComponent';
+import BayviewCalendar from '@/components/Input/BayviewCalendar';
 
 export default function Search() {
 	const { dispatch, flightState } = useContext(FlightContext);
@@ -121,22 +122,19 @@ export default function Search() {
 					/>
 				</InputPair>
 				<InputPair icon={faArrowRight}>
-					<Input
+					<BayviewCalendar
 						label="Departure Date"
-						defaultValue={flightState.searchState.formValues?.departure_date || ''}
-						type="date"
+						value={flightState.searchState.formValues?.departure_date}
 						name="departure_date"
-						icon={{ icon: faCalendarDays }}
 						placeholder="Date"
-						required
+						minDate={new Date(Date.now())}
 					/>
-					<Input
+					<BayviewCalendar
 						label="Return Date"
-						defaultValue={flightState.searchState.formValues?.return_date || ''}
-						type="date"
+						value={flightState.searchState.formValues?.return_date}
 						name="return_date"
-						icon={{ icon: faCalendarDays }}
 						placeholder="Date"
+						minDate={new Date(Date.now())}
 					/>
 				</InputPair>
 				<InputPair>

--- a/src/components/HomePage/Card/FlightCard/Presentations/Select.tsx
+++ b/src/components/HomePage/Card/FlightCard/Presentations/Select.tsx
@@ -34,6 +34,7 @@ type FlightStateSelectType = {
 type ResultsSortingProps = FlightStateSelectType & {
 	sortDataBySortingType: (sortBy: string, currentOffers: Offer[]) => void;
 	setCurrentPage: Dispatch<SetStateAction<number>>;
+	setCurrentOffers: Dispatch<SetStateAction<Array>>;
 	currentOffers: Offer[] | undefined;
 	isDepartingPresentation: boolean;
 };
@@ -227,7 +228,7 @@ export default function SelectFlight() {
 
 			// Update the displayed offers directly with sorted data
 			setDisplayedOffers(sortedOffers.slice(0, currentPage * itemsPerPage));
-
+			
 			return sortedOffers;
 		} else {
 			return [];
@@ -246,8 +247,6 @@ export default function SelectFlight() {
 
 	// Handler to load more offers
 	const loadMoreOffers = () => {
-		// // Determine the current set of offers based on the state
-		// const currentOffers = getCurrentOffers();
 
 		// Calculate the next set of offers to be displayed
 		const nextOffers = currentOffers?.slice(0, currentPage * itemsPerPage);
@@ -358,6 +357,7 @@ export default function SelectFlight() {
 							<ResultsSorting
 								flightState={flightState.selectState}
 								setCurrentPage={setCurrentPage}
+								setCurrentOffers={setCurrentOffers}
 								dispatch={dispatch}
 								sortDataBySortingType={sortDataBySortingType}
 								currentOffers={currentOffers}
@@ -487,8 +487,10 @@ FAIcon.displayName = 'FAIcon';
 // Edit details section
 const EditSearchDetails = React.memo(
 	({ flightState, dispatch, currentOffers, isDepartingPresentation, handleModifyDeparting }: EditSearchDetailsProps) => {
-		const prettyPrintDate = (dateString) =>
-			`${parseInt(dateString.substring(5, 7), 10)}/${parseInt(dateString.substring(8, 10), 10)}/${dateString.substring(2, 4)}`;
+		const prettyPrintDate = dateString => {
+			const d = new Date(dateString);
+			return `${(d.getMonth() + 1).toString().padStart(2, '0')}/${d.getDate().toString().padStart(2, '0')}/${d.getFullYear().toString().slice(-2)}`;
+		};
 
 		return (
 			<motion.div>
@@ -620,7 +622,7 @@ EditSearchDetails.displayName = 'EditSearchDetails';
 
 // Results and sort
 const ResultsSorting = React.memo(
-	({ flightState, dispatch, sortDataBySortingType, isDepartingPresentation, currentOffers }: ResultsSortingProps) => {
+	({ flightState, dispatch, sortDataBySortingType, isDepartingPresentation, currentOffers, setCurrentOffers }: ResultsSortingProps) => {
 		const updateSortType = (e) => {
 			const sortBy = e.target.value;
 
@@ -643,9 +645,9 @@ const ResultsSorting = React.memo(
 							},
 						},
 				  });
-
+		    
 			// Reset page to ensure we get the accurate results after sorting change, must be in this order.
-			sortDataBySortingType(sortBy, currentOffers ? currentOffers : []); // Sort all offers
+			setCurrentOffers(sortDataBySortingType(sortBy, currentOffers ? currentOffers : [])); // Sort all offers
 		};
 
 		return (

--- a/src/components/HomePage/Card/FlightCard/Presentations/Select.tsx
+++ b/src/components/HomePage/Card/FlightCard/Presentations/Select.tsx
@@ -34,7 +34,7 @@ type FlightStateSelectType = {
 type ResultsSortingProps = FlightStateSelectType & {
 	sortDataBySortingType: (sortBy: string, currentOffers: Offer[]) => void;
 	setCurrentPage: Dispatch<SetStateAction<number>>;
-	setCurrentOffers: Dispatch<SetStateAction<Array>>;
+	setCurrentOffers;
 	currentOffers: Offer[] | undefined;
 	isDepartingPresentation: boolean;
 };

--- a/src/components/HomePage/Card/LodgingCard/index.tsx
+++ b/src/components/HomePage/Card/LodgingCard/index.tsx
@@ -9,6 +9,7 @@ import Input from "@/components/Input";
 import InputPair from "@/components/Input/InputPair";
 import Button from "@/components/Button";
 import Card from "@/components/HomePage/Card";
+import BayviewCalendar from "@/components/Input/BayviewCalendar";
 
 export default function LodgingCard() {
   return (
@@ -22,19 +23,16 @@ export default function LodgingCard() {
           required
         />
         <InputPair icon={faArrowRight}>
-          <Input
+          <BayviewCalendar
             label="Check-In Date"
             name="check-in-date"
-            icon={{ icon: faCalendarDays }}
             placeholder="Check-in Date"
-            required
-          />
-          <Input
+						minDate={new Date(Date.now())}
+					/>
+          <BayviewCalendar
             label="Check-Out Date"
             name="check-out-date"
-            icon={{ icon: faCalendarDays }}
             placeholder="Check-Out Date"
-            required
           />
         </InputPair>
         <div className="display: flex gap-3">

--- a/src/components/Input/BayviewCalendar/calendar.css
+++ b/src/components/Input/BayviewCalendar/calendar.css
@@ -1,13 +1,11 @@
 .react-calendar {
-  width: 350px;
-  max-width: 100%;
-  background: white;
-  border: 1px solid;
-  border-color: rgb(229 231 235);
-  border-radius: 4px;
-  padding: 5px;
   font-family: var(--font-barlow);
   line-height: 1.125em;
+  @apply p-2 border-none bg-transparent max-w-full;
+}
+
+.react-calendar * {
+  @apply rounded;
 }
 
 .react-calendar--doubleView {
@@ -33,34 +31,35 @@
   box-sizing: border-box;
 }
 
-.react-calendar button {
-  margin: 0;
-  border: 0;
-  outline: none;
-}
-
 .react-calendar button:enabled:hover {
   cursor: pointer;
+  @apply bg-red-400 text-white;
+}
+
+.react-calendar button:disabled {
+  cursor: not-allowed;
+  @apply dark:bg-zinc-900 dark:text-zinc-700 bg-zinc-100 text-zinc-300;
+}
+
+.react-calendar__navigation > *:not(:disabled) {
+  @apply !bg-transparent;
+}
+
+.react-calendar__navigation__arrow:hover:not(:disabled) {
+  cursor: pointer;
+  @apply !bg-red-400 text-white;
+}
+
+.react-calendar__navigation__label:hover {
+  @apply !bg-red-400;
 }
 
 .react-calendar__navigation {
   display: flex;
-  height: 44px;
-  margin-bottom: 1em;
 }
 
 .react-calendar__navigation button {
-  min-width: 44px;
-  background: none;
-}
-
-.react-calendar__navigation button:disabled {
-  background-color: white;
-}
-
-.react-calendar__navigation button:enabled:hover,
-.react-calendar__navigation button:enabled:focus {
-  background-color: white;
+  @apply px-2 mx-0.5 bg-none;
 }
 
 .react-calendar__month-view__weekdays {
@@ -85,7 +84,7 @@
 }
 
 .react-calendar__month-view__days__day--weekend {
-  color: black;
+  @apply dark:text-zinc-400 text-black;
 }
 
 .react-calendar__month-view__days__day--neighboringMonth {
@@ -106,22 +105,26 @@
   line-height: 16px;
   font: inherit;
   font-size: 0.833em;
-  
+}
+
+.react-calendar__viewContainer {
+  @apply: !rounded-2xl !overflow-clip;
 }
 
 .react-calendar__tile:disabled {
-  color: darkgray;
+  @apply dark:bg-zinc-900 bg-zinc-400;
+  @apply dark:text-zinc-950;
+  @apply rounded-none;
 }
 
 .react-calendar__tile:enabled:hover,
 .react-calendar__tile:enabled:focus {
   background-color: lightcoral;
-    color: white;
-    border-radius: 4px;
+  color: white;
 }
 
 .react-calendar__tile--now {
-  background: white;
+  @apply bg-transparent;
   color: red;
 }
 
@@ -129,22 +132,22 @@
 .react-calendar__tile--now:enabled:focus {
    background-color: lightcoral;
     color: white;
-    border-radius: 4px;
 }
 
 .react-calendar__tile--hasActive {
-  background: #76baff;
+  background: red;
+  @apply text-white;
 }
 
 .react-calendar__tile--hasActive:enabled:hover,
 .react-calendar__tile--hasActive:enabled:focus {
-  background: #a9d4ff;
+  background: lightcoral;
+  @apply text-white;
 }
 
 .react-calendar__tile--active {
   background: red;
   color: white;
-  border-radius: 4px;
 }
 
 .react-calendar__tile--active:enabled:hover,

--- a/src/components/Input/BayviewCalendar/index.tsx
+++ b/src/components/Input/BayviewCalendar/index.tsx
@@ -23,7 +23,7 @@ const BayviewCalendar = ({ label, name, placeholder, value, minDate, disabled} :
   const [dialogPosition, setDialogPosition] = useState({ top: 0, left: 0 });
   const [inputValue, setInputValue] = useState(value || ''); // State for the input value
   const [dateValue, setDateValue] = useState<Date | null>(null); // State for the validated date
-  const inputRef = useRef<HTMLElement | undefined>(null); // Ref for the input element
+  const inputRef = useRef<HTMLDivElement>(null); // Ref for the input element
 
   useEffect(() => {
     if (isOpen && inputRef.current) {
@@ -40,7 +40,7 @@ const BayviewCalendar = ({ label, name, placeholder, value, minDate, disabled} :
     setIsOpen(true);
   }
 
-  const handleChange = (value: Date) => {
+  const handleChange = (value) => {
     setDateValue(value);
     setInputValue(value.toDateString());
     setIsOpen(false);

--- a/src/components/Input/BayviewCalendar/index.tsx
+++ b/src/components/Input/BayviewCalendar/index.tsx
@@ -1,18 +1,36 @@
-import React, {useState, Fragment } from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, {useState, Fragment, useEffect, useRef } from "react";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import "./calendar.css";
-import styles from "../input.module.css"
 import {
   faCalendarDays
 } from "@fortawesome/free-solid-svg-icons";
 import { Dialog, Transition } from "@headlessui/react";
+import Input from "@/components/Input";
+import Card from "@/components/HomePage/Card";
 
-const BayviewCalendar = ({ date, setDate, label, placeholder, title, minDate, disabled}) => {
+type calendarType = {
+  name: string;
+  label?: string;
+  placeholder?: string;
+  minDate?: Date;
+  disabled?: boolean;
+  value?: string;
+};
 
-  let [isOpen, setIsOpen] = useState(false);
+const BayviewCalendar = ({ label, name, placeholder, value, minDate, disabled} : calendarType) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [dialogPosition, setDialogPosition] = useState({ top: 0, left: 0 });
+  const [inputValue, setInputValue] = useState(value || ''); // State for the input value
+  const [dateValue, setDateValue] = useState<Date | null>(null); // State for the validated date
+  const inputRef = useRef<HTMLElement | undefined>(null); // Ref for the input element
 
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      const rect = inputRef.current.getBoundingClientRect();
+      setDialogPosition({ top: rect.bottom + window.scrollY -10, left: rect.left + window.scrollX });
+    }
+  }, [isOpen]);
 
   function closeModal() {
     setIsOpen(false);
@@ -22,67 +40,76 @@ const BayviewCalendar = ({ date, setDate, label, placeholder, title, minDate, di
     setIsOpen(true);
   }
 
-  const handleChange = (value) => {
-    setDate(value);
+  const handleChange = (value: Date) => {
+    setDateValue(value);
+    setInputValue(value.toDateString());
     setIsOpen(false);
   };
 
+  const onInputChange = (event) => {
+    setInputValue(event.target.value);
+  }
+
+  const onBlur = (event) => {
+    // Validate the date only when the input field loses focus
+    const inputDate = new Date(event.target.value);
+    if (!isNaN(inputDate.getTime())) {
+      setDateValue(inputDate); // Update dateValue with the valid date
+      setInputValue(inputDate.toDateString());
+    } else if(inputValue !== "") {
+      setDateValue(null); // Clear dateValue if invalid
+      setInputValue("")
+    }
+  }
+
   return (
-    <>
-      {label ? (
-        <label className={styles.label}>{label}</label>
-      ) : (
-        <div className="w-full h-7"></div>
-      )}
+		<>
+			<div ref={inputRef}>
+				<Input
+					label={label}
+          autoComplete="off"
+					name={name}
+          onChange={onInputChange}
+          onBlur={onBlur}
+					placeholder={placeholder}
+          value={inputValue} 
+					icon={{ icon: faCalendarDays, onClick: !disabled ? openModal : undefined }}
+					required
+				/>
+			</div>
 
-      <div className="relative">
-        <div className={styles.inputWrapper}>
-          <FontAwesomeIcon
-            className={styles.icon}
-            icon={faCalendarDays}
-            onClick={disabled === true ? () => {}: openModal}
-          />
-          <input
-            className={styles.input}
-            disabled={disabled}
-            placeholder = {date === null ? placeholder: ""}
-            required
-            value={date === null ? "" : date.toLocaleDateString()}
-          ></input>
-        </div>
-
-        <Transition appear show={isOpen} as={Fragment}>
-          <Dialog open={isOpen} onClose={closeModal}>
-            <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-
-            <div className="fixed inset-0 flex w-screen items-center justify-center">
-              <Transition.Child
-                as={Fragment}
-                enter="ease-out duration-300"
-                enterFrom="opacity-0 scale-95"
-                enterTo="opacity-100 scale-100"
-                leave="ease-in duration-200"
-                leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
-              >
-                <Dialog.Panel className="w-full max-w-xs max-h-min rounded bg-white pl-5 pb-5 pr-5 border-4 border-gray-200">
-                  <div className="text-2xl font-bold text-center pb-3 pt-2">
-                    <Dialog.Title>Select {title} Date</Dialog.Title>
-                  </div>
-                  <div></div>
-                  <Calendar
-                    minDate={minDate}
-                    value={date}
-                    onChange={handleChange}
-                  />
-                </Dialog.Panel>
-              </Transition.Child>
-            </div>
-          </Dialog>
-        </Transition>
-      </div>
-    </>
-  );
+			<Transition appear show={isOpen} as={Fragment}>
+				<Dialog open={isOpen} onClose={closeModal}>
+					{/* <div className="fixed inset-0 bg-black/30" aria-hidden="true" /> */}
+					<div
+						className={`fixed inset-0 flex h-min`}
+						style={{
+							position: 'absolute',
+							top: `${dialogPosition.top}px`,
+							left: `${dialogPosition.left}px`,
+						}}
+					>
+						<Transition.Child
+							as={Fragment}
+							enter="ease-out duration-300"
+							enterFrom="opacity-0 scale-95"
+							enterTo="opacity-100 scale-100"
+							leave="ease-in duration-200"
+							leaveFrom="opacity-100 scale-100"
+							leaveTo="opacity-0 scale-95"
+						>
+							<Dialog.Panel>
+								<Card className="w-full max-w-xs max-h-min shadow-2xl">
+									{/* <Dialog.Title className="text-2xl font-bold text-center pb-3 pt-2">Select {title} Date</Dialog.Title> */}
+									<Calendar minDate={minDate} value={dateValue} onChange={handleChange} />
+								</Card>
+							</Dialog.Panel>
+						</Transition.Child>
+					</div>
+				</Dialog>
+			</Transition>
+		</>
+	);
 };
 
 export default BayviewCalendar;

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -14,8 +14,13 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { IconDefinition} from "@fortawesome/fontawesome-svg-core";
 import styles from "./input.module.css";
 
+type IconProps = Omit<FontAwesomeIconProps, "icon"> & {
+  icon: IconProp;
+  onClick?: (event: MouseEvent) => void;
+};
+
 export type UserInputProps = {
-  icon?: Omit<FontAwesomeIconProps, "icon"> & { icon: IconProp };
+  icon?: IconProps;
   label?: string;
 } & DetailedHTMLProps<
   InputHTMLAttributes<HTMLInputElement>,


### PR DESCRIPTION
### Description
This PR refactors the BayViewCalendar Component introduced in #85 by @cpilande and fixes an issue in the flight component with sorted results.

Changes include:
- Makes use of default input and card components for shared styles
- Updates the input to allow for entering valid dates in multiple forms. Invalid dates are cleared on change
- Updates the Flight, Lodging, and Dining Card to use the new inputs
- Changes the Calendar Component display to act as a popup under the textfield vs as a pure modal
- Updates styles and adds darkmode to existing component
- Fixes bug in Flight Card  where "Sorting by result type may be inaccurate due to unloaded items not being factored into client-side sorting at the time of effect call."

### Motivation and Context
This provides a better input modality for dates on the homepage and unifies styles and components. 

### Screenshots:

https://github.com/heyitsmass/BayView/assets/38991991/9147f48b-5517-4110-85a7-72493a30a8ff

### Additional Notes
It is still currently possible to enter dates outside of the range using manual input.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
