### PR TITLE
Calendar Input Optional Date Time

### DIFF
--- a/src/components/HomePage/Card/LodgingCard/index.tsx
+++ b/src/components/HomePage/Card/LodgingCard/index.tsx
@@ -24,15 +24,18 @@ export default function LodgingCard() {
         />
         <InputPair icon={faArrowRight}>
           <BayviewCalendar
-            label="Check-In Date"
+            label="Check-In Date / Time"
             name="check-in-date"
-            placeholder="Check-in Date"
+            placeholder="Check-in Date / Time"
 						minDate={new Date(Date.now())}
+            includeTime
 					/>
           <BayviewCalendar
-            label="Check-Out Date"
+            label="Check-Out Date / Time"
             name="check-out-date"
-            placeholder="Check-Out Date"
+            placeholder="Check-Out Date / Time"
+            minDate={new Date(Date.now())}
+            includeTime
           />
         </InputPair>
         <div className="display: flex gap-3">

--- a/src/components/Input/BayviewCalendar/calendar.css
+++ b/src/components/Input/BayviewCalendar/calendar.css
@@ -158,3 +158,21 @@
 .react-calendar--selectRange .react-calendar__tile--hover {
   background-color: #e6e6e6;
 }
+
+.hide-time-icon::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
+.hide-time-icon::-webkit-inner-spin-button,
+.hide-time-icon::-webkit-clear-button {
+  display: none;
+}
+
+.hide-time-icon::-ms-clear,
+.hide-time-icon::-ms-reveal {
+  display: none;
+}
+
+.hide-time-icon {
+  -moz-appearance: textfield; /* For Firefox */
+}

--- a/src/components/Input/BayviewCalendar/index.tsx
+++ b/src/components/Input/BayviewCalendar/index.tsx
@@ -3,84 +3,238 @@ import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import "./calendar.css";
 import {
-  faCalendarDays
+  faCalendarDays,
+  faClock
 } from "@fortawesome/free-solid-svg-icons";
 import { Dialog, Transition } from "@headlessui/react";
 import Input from "@/components/Input";
 import Card from "@/components/HomePage/Card";
+import Button from "@/components/Button";
 
 type calendarType = {
   name: string;
   label?: string;
   placeholder?: string;
   minDate?: Date;
+  includeTime?: boolean;
   disabled?: boolean;
   value?: string;
 };
 
-const BayviewCalendar = ({ label, name, placeholder, value, minDate, disabled} : calendarType) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [dialogPosition, setDialogPosition] = useState({ top: 0, left: 0 });
-  const [inputValue, setInputValue] = useState(value || ''); // State for the input value
-  const [dateValue, setDateValue] = useState<Date | null>(null); // State for the validated date
-  const inputRef = useRef<HTMLDivElement>(null); // Ref for the input element
+const BayviewCalendar = ({ label, name, placeholder, value, minDate, includeTime, disabled} : calendarType) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const [dialogPosition, setDialogPosition] = useState({ top: 0, left: 0 });
+	const [inputValue, setInputValue] = useState(value || ''); // State for the input value
+	const [dateValue, setDateValue] = useState<Date | null>(null); // State for the validated date
+	const [timeValue, setTime] = useState('12:00');
+	const inputRef = useRef<HTMLDivElement>(null); // Ref for the input element
+	const timeRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (isOpen && inputRef.current) {
-      const rect = inputRef.current.getBoundingClientRect();
-      setDialogPosition({ top: rect.bottom + window.scrollY -10, left: rect.left + window.scrollX });
+	useEffect(() => {
+		if (isOpen && inputRef.current) {
+			const rect = inputRef.current.getBoundingClientRect();
+			setDialogPosition({ top: rect.bottom + window.scrollY - 10, left: rect.left + window.scrollX });
+		}
+	}, [isOpen]);
+
+	function closeModal() {
+		setIsOpen(false);
+	}
+
+	function openModal() {
+		setIsOpen(true);
+	}
+
+	const handleChange = (value) => {
+		setDateValue(value);
+		setInputValue(value.toDateString());
+		setIsOpen(false);
+	};
+
+	const handleDateTimeChange = (value) => {
+    if(timeRef) {
+      // @ts-ignore
+      setTime(timeRef.current.value);
     }
-  }, [isOpen]);
+    // @ts-ignore
+    const updatedDate = combineDateAndTime(value, timeRef.current.value);
+    setDateValue(updatedDate);
+    setInputValue(formatDateTime(updatedDate)); 
+	};
 
-  function closeModal() {
-    setIsOpen(false);
-  }
+	const onInputChange = (event) => {
+		setInputValue(event.target.value);
+	};
 
-  function openModal() {
-    setIsOpen(true);
-  }
-
-  const handleChange = (value) => {
-    setDateValue(value);
-    setInputValue(value.toDateString());
-    setIsOpen(false);
+  const onInputTimeChange = (event) => {
+    setInputValue(event.target.value);
+    setTime(extractTimeForInput(event.target.value));
   };
 
-  const onInputChange = (event) => {
-    setInputValue(event.target.value);
+  // Helper function to reparse date from string
+  const extractDateFromString = (dateStr) => {
+    const parts = dateStr.match(/(\w{3}) (\w{3}) (\d{2}) (\d{2}) (\d{2}):(\d{2}) (\w{2})/);
+    if (!parts) {
+        return null;
+    }
+
+    const [, , month, day, year, hours, minutes, ampm] = parts;
+    const months = {
+        Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5,
+        Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11
+    };
+
+    let hourNumber = parseInt(hours, 10);
+    if (ampm.toLowerCase() === 'pm' && hourNumber < 12) {
+        hourNumber += 12;
+    }
+    if (ampm.toLowerCase() === 'am' && hourNumber === 12) {
+        hourNumber = 0;
+    }
+
+    const fullYear = 2000 + parseInt(year, 10); // Assuming the year is 20xx
+    const monthIndex = months[month];
+    const dayNumber = parseInt(day, 10);
+    const minuteNumber = parseInt(minutes, 10);
+
+    return new Date(fullYear, monthIndex, dayNumber, hourNumber, minuteNumber);
   }
 
-  const onBlur = (event) => {
-    // Validate the date only when the input field loses focus
-    const inputDate = new Date(event.target.value);
-    if (!isNaN(inputDate.getTime())) {
-      setDateValue(inputDate); // Update dateValue with the valid date
-      setInputValue(inputDate.toDateString());
-    } else if(inputValue !== "") {
-      setDateValue(null); // Clear dateValue if invalid
-      setInputValue("")
+  const onTimeChange = (event) => {
+    if(timeRef.current) {
+      setTime(timeRef.current.value);
+      const updatedDate = combineDateAndTime(dateValue, timeRef.current.value);
+      setDateValue(updatedDate);
+      setInputValue(formatDateTime(updatedDate)); 
+    } else {
+      setInputValue(combineDateAndTime(formatDateTime(event.target.value), extractTimeForInput(event.target.value))); 
     }
   }
 
-  return (
+  const formatDateTime = (date) => {
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    
+    const day = days[date.getDay()];
+    const month = months[date.getMonth()];
+    const dateNum = date.getDate();
+    const year = date.getFullYear().toString().substr(-2);
+    let hours = date.getHours();
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    const ampm = hours >= 12 ? 'PM' : 'AM';
+
+    hours = hours % 12;
+    hours = hours ? hours : 12; // the hour '0' should be '12'
+
+    return `${day} ${month} ${dateNum} ${year} ${hours}:${minutes} ${ampm}`;
+  };
+
+	// Function to combine a date and a time string into a single Date object
+	const combineDateAndTime = (date, timeString) => {
+		const time = timeString.match(/(\d+):(\d+)\s?(AM|PM)?/i);
+		if (!time) return date;
+
+		let [, hours, minutes, modifier] = time;
+		hours = parseInt(hours, 10);
+		minutes = parseInt(minutes, 10);
+
+		if (modifier) {
+			// Convert 12-hour time to 24-hour time for PM
+			if (modifier.toLowerCase() === 'pm' && hours < 12) {
+				hours += 12;
+			} // Convert 12-hour time to 24-hour time for AM
+			if (modifier.toLowerCase() === 'am' && hours === 12) {
+				hours = 0;
+			}
+		}
+
+		const combinedDate = new Date(date);
+		combinedDate.setHours(hours);
+		combinedDate.setMinutes(minutes);
+    return combinedDate;
+	};
+
+  const extractTimeForInput = (date) => {
+		const timePattern = /(\d{1,2}):(\d{2})\s?(AM|PM)/i;
+		const match = date.toString().match(timePattern);
+
+		if (!match) {
+			return '';
+		}
+
+		let [, hours, minutes, ampm] = match;
+		hours = parseInt(hours, 10);
+
+		// Convert 12-hour format to 24-hour format
+		if (ampm.toLowerCase() === 'pm' && hours < 12) {
+			hours += 12;
+		} else if (ampm.toLowerCase() === 'am' && hours === 12) {
+			hours = 0;
+		}
+
+		// Ensure hours are always two digits
+		hours = hours.toString().padStart(2, '0');
+		setTime(`${hours}:${minutes}`);
+    return `${hours}:${minutes}`;
+	};
+
+	const onBlur = (event) => {
+		// Validate the date only when the input field loses focus
+		const inputDate = new Date(event.target.value);
+		if (!isNaN(inputDate.getTime())) {
+			setDateValue(inputDate); // Update dateValue with the valid date
+			setInputValue(inputDate.toDateString());
+		} else if (inputValue !== '') {
+			setDateValue(null); // Clear dateValue if invalid
+			setInputValue('');
+		}
+	};
+
+  const onBlurTime = (event) => {
+		// Validate the date only when the input field loses focus
+		const inputDate = new Date(event.target.value);
+		if (!isNaN(inputDate.getTime())) {
+			setDateValue(inputDate); // Update dateValue with the valid date
+			setInputValue(formatDateTime(inputDate));
+		} else if (inputValue !== '') {
+			setDateValue(null); // Clear dateValue if invalid
+			setInputValue('');
+      setTime('12:00'); 
+		}
+	};
+
+	return (
 		<>
-			<div ref={inputRef}>
+			{includeTime && <div ref={inputRef}>
 				<Input
 					label={label}
-          autoComplete="off"
+					autoComplete="off"
 					name={name}
-          onChange={onInputChange}
-          onBlur={onBlur}
+					onChange={onInputTimeChange}
+					onBlur={onBlurTime}
+          value={inputValue}
 					placeholder={placeholder}
-          value={inputValue} 
 					icon={{ icon: faCalendarDays, onClick: !disabled ? openModal : undefined }}
 					required
 				/>
-			</div>
+			</div>}
+
+      {!includeTime && <div ref={inputRef}>
+				<Input
+					label={label}
+					autoComplete="off"
+					name={name}
+					onChange={onInputChange}
+					onBlur={onBlur}
+					placeholder={placeholder}
+					value={inputValue}
+					icon={{ icon: faCalendarDays, onClick: !disabled ? openModal : undefined }}
+					required
+				/>
+			</div>}
 
 			<Transition appear show={isOpen} as={Fragment}>
 				<Dialog open={isOpen} onClose={closeModal}>
-					{/* <div className="fixed inset-0 bg-black/30" aria-hidden="true" /> */}
 					<div
 						className={`fixed inset-0 flex h-min`}
 						style={{
@@ -99,10 +253,41 @@ const BayviewCalendar = ({ label, name, placeholder, value, minDate, disabled} :
 							leaveTo="opacity-0 scale-95"
 						>
 							<Dialog.Panel>
-								<Card className="w-full max-w-xs max-h-min shadow-2xl">
-									{/* <Dialog.Title className="text-2xl font-bold text-center pb-3 pt-2">Select {title} Date</Dialog.Title> */}
-									<Calendar minDate={minDate} value={dateValue} onChange={handleChange} />
-								</Card>
+								<div className="flex justify-center align-middle h-full">
+									<Card className="w-full max-w-xs max-h-100 shadow-2xl overflow-clip">
+										{includeTime ? (
+											<>
+												<Calendar minDate={minDate} value={dateValue} onChange={handleDateTimeChange} />
+												<div className="bg-zinc-200 w-[75%] m-auto h-0.5 mt-2 rounded-full"></div>
+												<div className="flex align-middle items-center content-around mt-2 w-full h-full">
+													<div className="flex w-4/6">
+														<Input
+															ref={timeRef}
+                              value={timeValue}
+															onChange={onTimeChange}
+															icon={{
+																icon: faClock,
+																onClick: (e) => {
+																	timeRef.current?.showPicker();
+																},
+															}}
+															type="time"
+															label="Time"
+															className="w-full pl-2 hide-time-icon"
+														></Input>
+													</div>
+													<div className="w-1/6 h-full flex items-center align-middle mt-3 mx-auto">
+														<Button variant="primary" onClick={() => setIsOpen(false)} className="-mb-3">
+															Ok
+														</Button>
+													</div>
+												</div>
+											</>
+										) : (
+											<Calendar minDate={minDate} value={dateValue} onChange={handleChange} />
+										)}
+									</Card>
+								</div>
 							</Dialog.Panel>
 						</Transition.Child>
 					</div>
@@ -111,5 +296,4 @@ const BayviewCalendar = ({ label, name, placeholder, value, minDate, disabled} :
 		</>
 	);
 };
-
 export default BayviewCalendar;

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -2,6 +2,7 @@
 import {
   DetailedHTMLProps,
   InputHTMLAttributes,
+  forwardRef,
   useCallback,
   useState, SyntheticEvent
 } from "react";
@@ -38,7 +39,7 @@ function useInputValidation(initialValue: string = "") {
 	return [input, validateInput] as const;
 }
 
-const UserInput = ({ ...props }: UserInputProps) => {
+const UserInput = forwardRef<HTMLInputElement, UserInputProps>((props, ref) => {
   const { icon, label, id, children, className } = props;
 
   const [input, validateInput] = useInputValidation();
@@ -61,11 +62,11 @@ const UserInput = ({ ...props }: UserInputProps) => {
       )}
       <div className={styles.inputWrapper}>
         {icon && <FontAwesomeIcon className={styles.icon} {...icon} />}
-        <input {...props} className={style} />
+        <input {...props} ref={ref} className={style} />
         {children}
       </div>
     </div>
   );
-};
-
+});
+UserInput.displayName = "UserInput";
 export default UserInput;


### PR DESCRIPTION
### Description
This PR add a new time input as an optional prop specified by passing `includeTime` to the existing BayViewCalendar Component and updates the lodging card (as an example) to take advantage of the shared time date object / modality.

### Motivation and Context
This unifies the collection of dates that require a predetermined time across components.

### Screenshots:

https://github.com/heyitsmass/BayView/assets/38991991/5f435ef3-594f-4e42-b13d-8b7bcff4b198



### Additional Notes
The implementation is somewhat messy and requires some refactoring for loading the appropriate values from save state.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
